### PR TITLE
Create tac-talk-guidelines.md

### DIFF
--- a/tac-talk-guidelines.md
+++ b/tac-talk-guidelines.md
@@ -1,0 +1,75 @@
+# Guidelines for Technical Advisory Council (TAC) talks
+
+The Technical Advisory Council (TAC) is part of the Confidential Computing Consortium (CCC), a non-profit organization under the Linux Foundation. The TAC provides a platform for discussing hardware-based trusted execution technologies, their benefits, drawbacks, and implementation approaches. We are a friendly group of a mix of industry representatives, academics, and open-source enthusiasts. The technical background of the audience members is thus a wild mix. Our TAC meetings are attended by: open-source developers that are interested in confidential computing; implementors on any level of the stack that work in industry; academics that write scientific papers about confidential computing on the software or hardwar side; cloud architects that develop solutions for cloud service providers or other large industry players; hardware architects at silicon companies that work on confidential computing features for next generation's products.
+
+Due to this mix, where the only real common ground is an interest in confidential computing, technical talks can be very interesting (and slightly unpredictable) to both the presenter and the audience. When presenting, you need to keep in mind that what you see as obvious in your work might not be known to all members in the audience. That being said, we do appreciate any talk and often enough, the Q&A after the talk ends in interesting debates.
+
+### TL;DR
+- No product pitches, just technical discussions on public topics
+- 20-30 minutes + following Q&A
+- Meetings are recorded and must follow Linux Foundation antitrust policies
+- [LFX meeting calendar](https://confidentialcomputing.io/get-involved/calendar/) for meeting invite
+- An email link to suggest a talk is at the bottom
+
+## Meeting Format
+- Technical presentations are typically 20-30 minutes
+- Followed by Q&A session (duration varies based on audience engagement)
+- Total presentation slot usually does not exceed 45 minutes
+- All meetings are public and open for anyone to participate
+- The recording of the meeting will later be published on [youtube](https://www.youtube.com/@confidentialcomputingconso5871/videos).
+- Meetings are held biweekly on Thursdays at 7am US Pacific Time (4pm Central European Time)
+- Note: Time differences may vary during daylight savings transitions
+- You can find the meeting invite and time in your time zone [on the LFX meeting calendar](https://confidentialcomputing.io/get-involved/calendar/)
+
+
+
+## Talk Categories
+Our talks can losely be grouped into three categories:
+
+1. **Open Source Talks**
+   - Project presentations. You did something and want to share it with the community.
+   - Paper results. You published something with an open-source artifact and want to share it with the community.
+   - Technical demos. You have a specific setup that is documented in an open-source repository and want to show it to the community so that it can be re-used.
+
+2. **Information Dissemination Talks**
+   - Educational content about approaches/technologies/methods. You think not enough people know about a topic but have no agenda to push one solution.
+     - These can be more in a lecture-style
+     - Treat this similar as an introductory lecture to a somewhat general audience
+
+3. **Interest Group/Discussion**
+    Sometimes, we want to engage with other communities or similar-minded organizations. Thus, not all talks have to be technical. These could be:
+   - Focused discussions on specific topics or organizations
+   - Community engagement on particular technical areas
+
+## Talk Content Guidelines
+### Preferred Topics
+Once you know what you want to talk about, here are some notes on what the TAC audience is particularly interested in:
+- Technical discussions on how and why confidential computing is used
+  - For example, why did you choose a TEE for this instead of some other solution?
+- Technology choices and their rationale
+- Threat models and trust models
+- End-to-end system considerations
+- System security architecture
+- Technical challenges and solutions
+- Implementation bottlenecks and their resolution
+
+### Content Restrictions
+Due to anti-trust regulations, technical talks must be limited to:
+1. Open-source projects that are public
+2. General technical discussions that extend beyond specific open-source projects
+
+If you are uncertain, you can refer to the [Linux Foundation antitrust policy](https://www.linuxfoundation.org/legal/antitrust-policy) or ask one of the TAC members.
+
+## Presentation style and best practices
+- Focus on technical content rather than product pitches
+- Avoid marketing-style presentations
+- Sales pitches should be directed to the outreach committee
+- Technical solutions and research results are welcome
+- Focus on security architecture and implementation details
+- Prepare for technical questions from a diverse audience
+- Consider the varying technical backgrounds of attendees
+- Avoid proprietary or patent-specific content
+- Maintain focus on open-source and general technical discussions
+
+## Contact and Resources
+If you want to give a talk or have an idea for an interesting topic, feel free to send an email to [tac@lists.confidentialcomputing.io](mailto:tac@lists.confidentialcomputing.io?subject=Talk%20suggestion%3A%20%3Cyour%20idea%3E&body=Hi%20everyone!%20I%20have%20an%20idea%20for%20a%20talk%3A%0D%0A%0D%0ATitle%20or%20topic%3A%20%3CSpecific%20title%20or%20topic%20idea%3E%0D%0ARelated%20URL%3A%20%3Crepository%2Fpaper%20link%3E%0D%0APotential%20presenters%3A%20%3Cyou%2Fsomeone%20else%2Fsomeone%20you%20are%20suggesting%3E%0D%0AStyle%3A%20%3Csee%20TAC%20talk%20guidelines%20about%20talk%20categories%3E)


### PR DESCRIPTION
Finally got around to write a guideline document for TAC talks.

Please feel free to suggest changes or directly push edits. This should also be a living thing, so once we realize that the talk categories I came up with are not realistic, we should change this. I do not see these categories as hard lines (or even anything we mention during the TAC meetings), but I think they will help speakers to categorize themselves into a group.